### PR TITLE
docs: professional README rewrite for portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,58 @@
-# KopuruVespaCompetitionIE
-IE Business School team (WaspBusters) for the [**2021 Kopuru Vespa Velutina**](https://kopuru.com/desafio/vespa-velutina/) data science competition.
+# KopuruVespaCompetitionIE — WaspBusters
 
-This is the script+data workflow followed for each submission:
-![WaspBusters workflow](https://github.com/IEwaspbusters/KopuruVespaCompetitionIE/raw/main/Competition_subs/Beeswax.jpg "THE BEESWAX is the glue that keeps it all together")
+IE Business School team (**WaspBusters**) entry for the [**2021 Kopuru Vespa Velutina**](https://kopuru.com/desafio/vespa-velutina/) data science competition — predicting invasive Asian hornet (*Vespa velutina*) nest locations in Spain.
 
-This is the Git workflow used by the team:
+🏆 **Award-winning submission.** Final presentation delivered at IE's Data Science Bootcamp:  
+[▶ Watch the final presentation (YouTube)](https://www.youtube.com/live/23Fua779WEA?si=haThQVCd2pDfZfPt&t=5671)
 
-PENDING: add the instructions for installing: geopandas, datawig and xgboost
+> Preserved for portfolio reference. Competition concluded in 2021; not actively maintained.
 
-First, set up the Jupyter Lab environment with the [Git extension](https://github.com/jupyterlab/jupyterlab-git). This is for Windows only:
-1. Install Anaconda
-2. Run `conda install -c conda-forge jupyterlab-git` in the conda terminal
-3. In conda terminal, run `conda install -c conda-forge nodejs`
-4. In conda terminal, run `conda install -c anaconda git` (if first time installing Git, then maybe also set up your credentials: `git config --global user.name "Your name here"`
-`git config --global user.email "your_email@example.com"`)
-5. Open jupyterlab
-6. Enable extensions (puzzle icon in the left bar)
-7. Scroll down to @jupyterlab/git and click `install`
-8. When jupyterlab asks to build the git extension, click `build`. Then wait for it to finish and then reload jupyterlab
-9. Maybe, just maybe, a git update from the jupyterlab console may be in order `pip install --upgrade jupyterlab-git`
-10. Maybe, just maybe, if the cloning doesn't work right off the bat try in the jupyterlab console `git clone <repo url>` directly
-11. Still doesn't work? Reboot everything. Your laptop, Jupyter, Conda. All of it. Maybe a couple of times.
-12. **DO NOT** update Anaconda navigator nor Jupyter Lab beyond what comes by default in the initial install.
+---
 
-Now, let's get to work:
-1. One-time only: **"CLONE"** this repository in your local JupyterLab environment, using the [HTTPS URL](https://github.com/IEwaspbusters/KopuruVespaCompetitionIE.git)
-4. **PULL**. For each_time_you_edit in range([now, deadline, daily]), before editing, make sure you always **"Pull from remote"** the latest version of the repo
-5. Edit whatever script and data you need in the corresponding submission and batch folder. **.IPYNB** files are preferred in most cases
-6. **STAGE** any _Changed_ or _Untracked_ files (by clicking on the "+") that you want to commit (i.e. "save")
-7. **COMMIT**. Write a short Summary of the changes you are introducing and then click **Commit**
-8. **PUSH**. Now **Push to remote** the commit you just made to see them reflected in [the WaspBuster's GitHub repo](https://github.com/IEwaspbusters/KopuruVespaCompetitionIE)
+## About the competition
 
-EOF
+The [Kopuru Vespa Velutina challenge](https://kopuru.com/desafio/vespa-velutina/) tasked teams with building a predictive model to identify likely locations of invasive hornet nests, using open geospatial and environmental data. The goal: support public authorities in prioritising inspection resources.
+
+## Our approach (the Beeswax workflow)
+
+![WaspBusters workflow](B_Submissions_Kopuru_competition/Beeswax.jpg "THE BEESWAX — the glue that keeps it all together")
+
+Each submission followed this script+data pipeline:
+
+1. Ingest and clean open geospatial datasets
+2. Feature engineering (environmental, spatial, temporal)
+3. Model training and iteration (XGBoost, etc.)
+4. Submit predictions to Kopuru platform
+5. Evaluate leaderboard score and iterate
+
+## Repository structure
+
+```
+KopuruVespaCompetitionIE/
+├── A_Wasp_nests_prediction_model/   # Model scripts and feature engineering
+├── B_Submissions_Kopuru_competition/ # Submission batches and workflow diagram
+├── C_IE_bootcamp_presentations/     # Final bootcamp presentation (PDF)
+├── Input_open_data/                 # Source datasets used
+└── Other_open_data/                 # Supplementary data sources
+```
+
+## Stack
+
+- Python (Pandas, scikit-learn, XGBoost, geopandas)
+- Jupyter Notebooks / JupyterLab
+- Data: open geospatial sources (sightings, environmental, administrative)
+
+## Team
+
+IE Business School Data Science Bootcamp cohort, Jan 2021 — team **WaspBusters**.
+
+---
+
+## Development environment setup (historical reference)
+
+The team used JupyterLab with the Git extension on Windows/Anaconda. If reproducing locally:
+
+1. Install [Anaconda](https://www.anaconda.com/)
+2. `conda install -c conda-forge jupyterlab-git nodejs`
+3. Clone this repository and open in JupyterLab
+4. Install additional dependencies: `geopandas`, `datawig`, `xgboost`


### PR DESCRIPTION
- Add competition context, award mention, and link to final presentation
- Fix workflow image path (was Competition_subs/, now correct B_Submissions_Kopuru_competition/)
- Describe Beeswax pipeline, repo structure, and stack
- Archive note: competition concluded 2021, not maintained
- Trim verbose JupyterLab setup to a clean historical reference section